### PR TITLE
Revert "Bump idna from 2.9 to 3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask-Shelve==0.1.1
 Flask-SQLAlchemy==2.4.4
 Flask-Uploads==0.2.1
 Flask-WTF==0.14.3
-idna==3.1
+idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.2
 joblib==1.0.0


### PR DESCRIPTION
Reverts Tokinoharu/Tourisit#16

Alex says 3.1 conflicts with another dependency.